### PR TITLE
Assistant checkpoint: Cập nhật check trùng verification theo attachme…

### DIFF
--- a/server/kafka-consumer.ts
+++ b/server/kafka-consumer.ts
@@ -830,7 +830,7 @@ function parseMessage(
       return message as FeedbackMessage;
     }
     // Check for support/contact message (has full_name, email, subject, content)
-    else if ("full_name" in message && "email" in message && "subject" in message && "content" in message) {
+    else if ("full_name" in message && "email" in message && "subject" in message &&"content" in message) {
       return message as SupportMessage;
     } else if ("externalId" in message){
       return message as ContentMessage;
@@ -1403,24 +1403,34 @@ async function processVerificationMessage(message: VerificationMessage, tx: any)
       return;
     }
 
-    // Check for duplicate verification request based on email and id
-    const existingRequest = await tx
-      .select()
-      .from(supportRequests)
-      .where(
-        and(
-          eq(supportRequests.email, message.email),
-          eq(supportRequests.type, "verify")
-        )
-      )
-      .limit(1);
+    // Check for duplicate verification request ONLY based on attachment_url (if provided)
+    // This allows multiple verification requests from same email/user for different purposes
+    if (message.attachment_url) {
+      const attachmentUrlString = Array.isArray(message.attachment_url) ? 
+        JSON.stringify(message.attachment_url) : 
+        message.attachment_url;
 
-    if (existingRequest.length > 0) {
-      log(`Verification request for ${message.email} already exists, skipping...`, "kafka");
-      return existingRequest[0];
+      const existingRequest = await tx
+        .select()
+        .from(supportRequests)
+        .where(
+          and(
+            eq(supportRequests.attachment_url, attachmentUrlString),
+            eq(supportRequests.type, "verify")
+          )
+        )
+        .limit(1);
+
+      if (existingRequest.length > 0) {
+        log(`Verification request with same attachment_url already exists, skipping...`, "kafka");
+        return existingRequest[0];
+      }
     }
 
+    // If no attachment_url or it's unique, proceed to create new request
+
     log(`Processing verification message: ${JSON.stringify(message)}`, "kafka");
+    log(`Note: Multiple verification requests from same email/user are allowed. Only checking for duplicate attachment_url if provided.`, "kafka");
 
     // Get active users (exclude admin for verification assignment)
     const activeUsers = await tx


### PR DESCRIPTION
…nt_url

Assistant generated file changes:
- server/kafka-consumer.ts: Cập nhật logic check trùng cho verification messages - chỉ check theo attachment_url thay vì identity_verification_id

---

User prompt:

Không, hiện tại bên service gửi, được phép cho gửi trùng identity_verification_id, chỉ cần check trùng attachment_url bạn nhé. Còn các trường khác được phép giống nhau

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: d98e7997-c9dd-4243-b7d7-1321a014cfa0